### PR TITLE
Imp adapters compatible with newer marshmallow

### DIFF
--- a/cchloader/adapters/__init__.py
+++ b/cchloader/adapters/__init__.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema
+from marshmallow import Schema, post_load
 from marshmallow.decorators import tag_processor
 from cchloader.models import Document
 
@@ -16,5 +16,6 @@ class CchAdapter(Schema):
     """Base Cch Adapter.
     """
 
+    @post_load
     def make_object(self, data):
         return Document(data, adapter=self)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 raven
 pymongo<3.0
 osconf
-marshmallow==2.0.0b2
+marshmallow>=2.0.0b2
 click


### PR DESCRIPTION
Allows cchloader to work with newer versions of the marshmallow library