### PR TITLE
Allow newer versions of marshmallow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 raven
 pymongo<3.0
 osconf
-marshmallow>=2.0.0b2
+marshmallow>=2.13.5
 click

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "raven",
         "pymongo<3.0",
         "osconf",
-        "marshmallow>=2.0.0b2",
+        "marshmallow>=2.13.5",
         "click"
     ],
     test_suite='',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "raven",
         "pymongo<3.0",
         "osconf",
-        "marshmallow==2.0.0b2",
+        "marshmallow>=2.0.0b2",
         "click"
     ],
     test_suite='',


### PR DESCRIPTION
The requirements waren't changed on the setup.py file so the marshmallow was still on 2.0.0 version