### PR TITLE
Fix validated field and quality range

### DIFF
--- a/cchloader/adapters/p1.py
+++ b/cchloader/adapters/p1.py
@@ -33,7 +33,7 @@ class P1BaseAdapter(Schema):
             data['source'] = None
 
     @pre_load
-    def fix_endesa_validated(self, data):
+    def fix_validated(self, data):
         source = data.get('validated')
         if not source:
             data['validated'] = 0

--- a/cchloader/adapters/p1.py
+++ b/cchloader/adapters/p1.py
@@ -33,6 +33,12 @@ class P1BaseAdapter(Schema):
             data['source'] = None
 
     @pre_load
+    def fix_endesa_validated(self, data):
+        source = data.get('validated')
+        if not source:
+            data['validated'] = 0
+
+    @pre_load
     def valid_measure(self, data):
         aoquality = data.get('aoquality')
         r1quality = data.get('r1quality')

--- a/cchloader/models/p1.py
+++ b/cchloader/models/p1.py
@@ -5,8 +5,8 @@ from marshmallow.validate import OneOf
 
 class P1Schema(Schema):
 
-    valid_quality = range(0,256)
-    valid_activa_quality = range(0,128)
+    valid_quality = range(0,255)
+    valid_activa_quality = range(0,255)
 
     name = fields.String(position=0, required=True)
     measure_type = fields.Integer(position=1) # hauria de ser sempre 11


### PR DESCRIPTION
This PR solves the problems found with the load of P1 files.
- The range of the quality values has been fixed to allow every value.
- A pre_load function has been added to set a value of 0 for the 'validated' field if it comes empty in the readed file.
