### PR TITLE
Adapt script do ERPpeek 1.7.1 version changes

### DIFF
--- a/scripts/get_cch.py
+++ b/scripts/get_cch.py
@@ -38,7 +38,9 @@ def config_connection(**kwargs):
 
 
 def get_cch(c):
-    providers = c.TgComerProvider.read([],[])
+    # providers = c.TgComerProvider.read([],[])
+    provider_ids = c.TgComerProvider.search([])
+    providers = c.TgComerProvider.read(provider_ids, [])
     for provider in providers:
          print "Loading {} CCH curves".format(provider['name'])
          c.TgComerReader.reader([provider['id']])


### PR DESCRIPTION
We used a read([], []) to obtain all providers but this is not working on 1.7.1.
Here we replace read for search&read of providers.