### PR TITLE
Se han añadido los modelos para las curvas A5D y B5D

### DIFF
--- a/cchloader/adapters/a5d.py
+++ b/cchloader/adapters/a5d.py
@@ -1,0 +1,38 @@
+from cchloader.adapters import CchAdapter
+from cchloader.models.cch_autocons import CchAutoconsSchema
+from marshmallow import Schema, fields, pre_load
+
+
+class A5dBaseAdapter(Schema):
+    """ A5D Adapter
+    """
+
+    @pre_load
+    def fix_numbers(self, data):
+        for attr, field in self.fields.iteritems():
+            if isinstance(field, fields.Integer):
+                if not data.get(attr):
+                    data[attr] = None
+        return data
+
+    @pre_load
+    def fix_season(self, data):
+        valid_values = [0, 1]
+        season = data.get('season')
+        if season and season.isdigit() and season in map(str, valid_values):
+            data['season'] = int(season)
+        else:
+            data['season'] = None
+
+    @pre_load
+    def fix_source(self, data):
+        valid_values = [1, 2, 3, 4, 5, 6]
+        source = data.get('source')
+        if source and source.isdigit() and int(source) in valid_values:
+            data['source'] = int(source)
+        else:
+            data['source'] = None
+
+
+class A5dAdapter(A5dBaseAdapter, CchAdapter, CchAutoconsSchema):
+    pass

--- a/cchloader/adapters/b5d.py
+++ b/cchloader/adapters/b5d.py
@@ -1,0 +1,38 @@
+from cchloader.adapters import CchAdapter
+from cchloader.models.cch_gennetabeta import CchGenNetaBetaSchema
+from marshmallow import Schema, fields, pre_load
+
+
+class B5dBaseAdapter(Schema):
+    """ B5D Adapter
+    """
+
+    @pre_load
+    def fix_numbers(self, data):
+        for attr, field in self.fields.iteritems():
+            if isinstance(field, fields.Integer):
+                if not data.get(attr):
+                    data[attr] = None
+        return data
+
+    @pre_load
+    def fix_season(self, data):
+        valid_values = [0, 1]
+        season = data.get('season')
+        if season and season.isdigit() and season in map(str, valid_values):
+            data['season'] = int(season)
+        else:
+            data['season'] = None
+
+    @pre_load
+    def fix_source(self, data):
+        valid_values = [1, 2, 3, 4, 5, 6]
+        source = data.get('source')
+        if source and source.isdigit() and int(source) in valid_values:
+            data['source'] = int(source)
+        else:
+            data['source'] = None
+
+
+class B5dAdapter(B5dBaseAdapter, CchAdapter, CchGenNetaBetaSchema):
+    pass

--- a/cchloader/models/cch_autocons.py
+++ b/cchloader/models/cch_autocons.py
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8 -*-
+from marshmallow import Schema, fields
+from marshmallow.validate import OneOf
+
+
+class CchAutoconsSchema(Schema):
+    name = fields.String(position=0, required=True)
+    datetime = fields.DateTime(position=1, format='%Y/%m/%d %H:%M')
+    season = fields.Integer(position=2, validate=OneOf([0, 1]))
+    ai = fields.Integer(position=3)
+    ae = fields.Integer(position=4, allow_none=True)
+    r1 = fields.Integer(position=5, allow_none=True)
+    r2 = fields.Integer(position=6, allow_none=True)
+    r3 = fields.Integer(position=7, allow_none=True)
+    r4 = fields.Integer(position=8, allow_none=True)
+    source = fields.Integer(position=9, validate=OneOf([1, 2, 3, 4, 5, 6]))
+    validated = fields.Boolean(position=10)
+    bill = fields.String(position=11)
+
+
+CchAutoconsSchema()

--- a/cchloader/models/cch_gennetabeta.py
+++ b/cchloader/models/cch_gennetabeta.py
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8 -*-
+from marshmallow import Schema, fields
+from marshmallow.validate import OneOf
+
+
+class CchGenNetaBetaSchema(Schema):
+    name = fields.String(position=0, required=True)
+    datetime = fields.DateTime(position=1, format='%Y/%m/%d %H:%M')
+    season = fields.Integer(position=2, validate=OneOf([0, 1]))
+    ai = fields.Integer(position=3)
+    ae = fields.Integer(position=4, allow_none=True)
+    r1 = fields.Integer(position=5, allow_none=True)
+    r2 = fields.Integer(position=6, allow_none=True)
+    r3 = fields.Integer(position=7, allow_none=True)
+    r4 = fields.Integer(position=8, allow_none=True)
+    source = fields.Integer(position=9, validate=OneOf([1, 2, 3, 4, 5, 6]))
+    validated = fields.Boolean(position=10)
+    bill = fields.String(position=11)
+
+
+CchGenNetaBetaSchema()

--- a/cchloader/parsers/__init__.py
+++ b/cchloader/parsers/__init__.py
@@ -3,3 +3,5 @@ from p5d import P5d
 from p1 import P1
 from f1 import F1
 from p1d import P1D
+from a5d import A5d
+from b5d import B5d

--- a/cchloader/parsers/a5d.py
+++ b/cchloader/parsers/a5d.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from cchloader import logger
+from cchloader.utils import build_dict
+from cchloader.adapters.a5d import A5dAdapter
+from cchloader.models.cch_autocons import CchAutoconsSchema
+from cchloader.parsers.parser import Parser, register
+
+
+class A5d(Parser):
+
+    patterns = ['^A5D_(\d+)_(\d{4})_(\d{4})(\d{2})(\d{2})']
+    encoding = "iso-8859-15"
+    delimiter = ';'
+
+    def __init__(self, strict=False):
+        self.adapter = A5dAdapter(strict=strict)
+        self.schema = CchAutoconsSchema(strict=strict)
+        self.fields = []
+        self.headers = []
+        for f in sorted(self.schema.fields, key=lambda f: self.schema.fields[f].metadata['position']):
+            field = self.schema.fields[f]
+            self.fields.append((f, field.metadata))
+            self.headers.append(f)
+
+    def parse_line(self, line):
+        slinia = tuple(unicode(line.decode(self.encoding)).split(self.delimiter))
+        slinia = map(lambda s: s.strip(), slinia)
+        parsed = {'cchfact': {}, 'orig': line}
+        data = build_dict(self.headers, slinia)
+        result, errors = self.adapter.load(data)
+        if errors:
+            logger.error(errors)
+        parsed['cchfact'] = result
+        return parsed, errors
+
+
+register(A5d)

--- a/cchloader/parsers/b5d.py
+++ b/cchloader/parsers/b5d.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from cchloader import logger
+from cchloader.utils import build_dict
+from cchloader.adapters.b5d import B5dAdapter
+from cchloader.models.cch_gennetabeta import CchGenNetaBetaSchema
+from cchloader.parsers.parser import Parser, register
+
+
+class B5d(Parser):
+
+    patterns = ['^B5D_(\d+)_(\d{4})_(\d{4})(\d{2})(\d{2})']
+    encoding = "iso-8859-15"
+    delimiter = ';'
+
+    def __init__(self, strict=False):
+        self.adapter = B5dAdapter(strict=strict)
+        self.schema = CchGenNetaBetaSchema(strict=strict)
+        self.fields = []
+        self.headers = []
+        for f in sorted(self.schema.fields, key=lambda f: self.schema.fields[f].metadata['position']):
+            field = self.schema.fields[f]
+            self.fields.append((f, field.metadata))
+            self.headers.append(f)
+
+    def parse_line(self, line):
+        slinia = tuple(unicode(line.decode(self.encoding)).split(self.delimiter))
+        slinia = map(lambda s: s.strip(), slinia)
+        parsed = {'cchfact': {}, 'orig': line}
+        data = build_dict(self.headers, slinia)
+        result, errors = self.adapter.load(data)
+        if errors:
+            logger.error(errors)
+        parsed['cchfact'] = result
+        return parsed, errors
+
+
+register(B5d)


### PR DESCRIPTION
## Objetivos

- Se deben poder cargar curvas de autoconsumo (A5D para consumo y B5D para generación)

## Nuevo comportamiento

- Se han creado los modelos para las dos curvas nuevas:
    - cch_autocons (A5D)
    - cch_gennetabeta (B5D)
- Para cada curva se ha creado el modelo, el adapter y el parser.

## Checklist

- [x] Test code