### PR TITLE
Floats a none P1 y F1

### DIFF
--- a/cchloader/adapters/f1.py
+++ b/cchloader/adapters/f1.py
@@ -9,7 +9,7 @@ class F1BaseAdapter(Schema):
     @pre_load
     def fix_numbers(self, data):
         for attr, field in self.fields.iteritems():
-            if isinstance(field, fields.Integer):
+            if isinstance(field, (fields.Integer, fields.Float)):
                 if not data.get(attr):
                     data[attr] = None
         return data

--- a/cchloader/adapters/p1.py
+++ b/cchloader/adapters/p1.py
@@ -10,7 +10,7 @@ class P1BaseAdapter(Schema):
     @pre_load
     def fix_numbers(self, data):
         for attr, field in self.fields.iteritems():
-            if isinstance(field, fields.Integer):
+            if isinstance(field, (fields.Integer, fields.Float)):
                 if not data.get(attr):
                     data[attr] = None
         return data


### PR DESCRIPTION
No tengo mucha idea de si este cambio tendria alguna afección mala, me he encontrado una serie de tests del erp que fallaban tras procesar floats vacios, por ejemplo test_manual_invoice_P1_31A_lb (procesa un zip de P1)

Al intentar procesar el float vacio de los recientemente cambiados campos de Integer a Float "reserve" tanto del p1 como el f1 daba un error de "Invalid number" y he visto que pasaba por esta funcion de fix numbers.

Hay otros campos float del F1 Y P1 que no dan el mismo error y no entiendo porque pero me hace pensar que el problema que me da puede venir de otro sitio.

Con estos cambios funciona