### PR TITLE
Fix mamba testing py2 support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 expects
-mamba
+mamba<=0.10.0
 


### PR DESCRIPTION
Fix testing removed `py2` support by `mamba` on: https://github.com/nestorsalceda/mamba/releases/tag/v0.11.0