### PR TITLE
Soporte para cargar ficheros REGANECU

### DIFF
--- a/cchloader/adapters/reganecu.py
+++ b/cchloader/adapters/reganecu.py
@@ -1,0 +1,20 @@
+from cchloader.adapters import CchAdapter
+from cchloader.models.reganecu import ReganecuSchema
+from marshmallow import Schema, fields, pre_load
+
+
+class ReganecuBaseAdapter(Schema):
+    """ REGANECU Adapter
+    """
+
+    @pre_load
+    def fix_numbers(self, data):
+        for attr, field in self.fields.iteritems():
+            if isinstance(field, (fields.Integer, fields.Float)):
+                if not data.get(attr):
+                    data[attr] = None
+        return data
+
+
+class ReganecuAdapter(ReganecuBaseAdapter, CchAdapter, ReganecuSchema):
+    pass

--- a/cchloader/models/reganecu.py
+++ b/cchloader/models/reganecu.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+from marshmallow import Schema, fields
+
+
+class ReganecuSchema(Schema):
+    date = fields.String(position=0, required=True)
+    hour = fields.Integer(position=1, required=True)
+    upr = fields.String(position=2, required=True)
+    energia = fields.Float(position=3, required=True)
+    reserved1 = fields.Integer(position=4, required=True)
+    precio = fields.Float(position=5, required=True)
+    reserved2 = fields.Integer(position=6, required=True)
+    importe = fields.Float(position=7, required=True)
+    reserved3 = fields.Integer(position=8, required=True)
+    vendedor = fields.String(position=9, required=True)
+    segmento = fields.String(position=10, required=True)
+    facturacion = fields.Integer(position=11, required=True)
+    eiec_upr = fields.String(position=12, required=True)
+    cuenta = fields.String(position=13, required=True)
+    signo_importe = fields.Integer(position=14, required=True)
+    signo_magnitud = fields.Integer(position=15, required=True)
+    eic_titular = fields.String(position=16, required=True)
+    codigo_magnitud = fields.String(position=17, required=True)
+    codigo_precio = fields.String(position=18, required=True)
+    codigo_apunte = fields.String(position=19, required=True)
+    tipo_oferta = fields.String(position=20, required=True)
+    tipo_upr = fields.Integer(position=21, required=True)
+    energia_bilateral = fields.Integer(position=22, required=True)
+    sesion = fields.String(position=23, required=True)
+
+
+ReganecuSchema()

--- a/cchloader/parsers/__init__.py
+++ b/cchloader/parsers/__init__.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 from f5d import F5d
 from p5d import P5d
 from p1 import P1
@@ -9,3 +10,4 @@ from p2 import P2
 from p2d import P2D
 from rf5d import Rf5d
 from mhcil import Mhcil
+from reganecu import Reganecu

--- a/cchloader/parsers/reganecu.py
+++ b/cchloader/parsers/reganecu.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from cchloader import logger
+from cchloader.utils import build_dict
+from cchloader.adapters.reganecu import ReganecuAdapter
+from cchloader.models.reganecu import ReganecuSchema
+from cchloader.parsers.parser import Parser, register
+
+
+class Reganecu(Parser):
+
+    patterns = ['^([ABC])(\d{1})_reganecu_(\d{4})(\d{2})(\d{2})_']
+    encoding = "iso-8859-15"
+    delimiter = ';'
+
+    def __init__(self, strict=False):
+        self.adapter = ReganecuAdapter(strict=strict)
+        self.schema = ReganecuSchema(strict=strict)
+        self.fields = []
+        self.headers = []
+        for f in sorted(self.schema.fields, key=lambda f: self.schema.fields[f].metadata['position']):
+            field = self.schema.fields[f]
+            self.fields.append((f, field.metadata))
+            self.headers.append(f)
+
+    def parse_line(self, line):
+        slinia = tuple(unicode(line.decode(self.encoding)).split(self.delimiter))
+        slinia = map(lambda s: s.strip(), slinia)
+        parsed = {'reganecu': {}, 'orig': line}
+        data = build_dict(self.headers, slinia)
+        result, errors = self.adapter.load(data)
+        if errors:
+            logger.error(errors)
+        parsed['reganecu'] = result
+        return parsed, errors
+
+
+register(Reganecu)


### PR DESCRIPTION
## Objetivo
- Implementar el modelo, el "parser" y el "adapter" para poder importar ficheros de liquidaciones `REGANECU`.

## Especificaciones
- El fichero `REGANECU` publica los registros de anotaciones en cuenta.

![Captura de pantalla de 2022-02-25 15-00-49](https://user-images.githubusercontent.com/49635897/155728085-59c2c3fc-d47b-4ac9-8b90-2f4858f92361.png)
