### PR TITLE
Soporte para la carga de ficheros MHCIL de cierre provisional (HP)

### DIFF
--- a/cchloader/parsers/mhcil.py
+++ b/cchloader/parsers/mhcil.py
@@ -9,8 +9,8 @@ from cchloader.parsers.parser import Parser, register
 
 class Mhcil(Parser):
 
-    patterns = ['^MHCIL_([H][23CD])_(\d{4})_([PA][12])_(\d{4})(\d{2})(\d{2}).(\d)',
-                '^MHCIL_([H][23CD])_(\d{4})_([PA][12])_(\d{4})(\d{2})(\d{2})']
+    patterns = ['^MHCIL_([H][23CP])_(\d{4})_([PA][12])_(\d{4})(\d{2})(\d{2}).(\d)',
+                '^MHCIL_([H][23CP])_(\d{4})_([PA][12])_(\d{4})(\d{2})(\d{2})']
     encoding = "iso-8859-15"
     delimiter = ';'
 


### PR DESCRIPTION
- Se ha añadido el cierre provisional (`HP`) a las opciones de carga del fichero `MHCIL`.