### PR TITLE
Soporte para cargar ficheros REGANECUQH

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ Eina d'importació de CCH
 - `P2`
 - `P2D`
 - `REGANECU`
+- `REGANECUQH`
 - `RF5D`

--- a/cchloader/adapters/reganecuqh.py
+++ b/cchloader/adapters/reganecuqh.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from cchloader.adapters import CchAdapter
+from cchloader.models.reganecuqh import ReganecuQhSchema
+from marshmallow import Schema, fields, pre_load
+
+
+class ReganecuQhBaseAdapter(Schema):
+    """ REGANECUQh Adapter
+    """
+
+    @pre_load
+    def fix_numbers(self, data):
+        for attr, field in self.fields.items():
+            if isinstance(field, (fields.Integer, fields.Float)):
+                if not data.get(attr):
+                    data[attr] = None
+        return data
+
+
+class ReganecuQhAdapter(ReganecuQhBaseAdapter, CchAdapter, ReganecuQhSchema):
+    pass

--- a/cchloader/models/reganecuqh.py
+++ b/cchloader/models/reganecuqh.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# -*- encoding: utf-8 -*-
+from __future__ import absolute_import
+
+from marshmallow import Schema, fields
+
+
+class ReganecuQhSchema(Schema):
+    date = fields.String(position=0, required=True)
+    reserved0 = fields.Integer(position=1, required=True)
+    upr = fields.String(position=2, required=True)
+    energia = fields.Float(position=3, required=True)
+    reserved1 = fields.Integer(position=4)
+    precio = fields.Float(position=5, required=True)
+    reserved2 = fields.Integer(position=6)
+    importe = fields.Float(position=7, required=True)
+    reserved3 = fields.Integer(position=8)
+    vendedor = fields.String(position=9, required=True)
+    segmento = fields.String(position=10, required=True)
+    facturacion = fields.Integer(position=11, required=True)
+    eiec_upr = fields.String(position=12, required=True)
+    cuenta = fields.String(position=13, required=True)
+    signo_importe = fields.Integer(position=14, required=True)
+    signo_magnitud = fields.Integer(position=15, required=True)
+    eic_titular = fields.String(position=16, required=True)
+    codigo_magnitud = fields.String(position=17, required=True)
+    codigo_precio = fields.String(position=18, required=True)
+    codigo_apunte = fields.String(position=19, required=True)
+    tipo_oferta = fields.String(position=20, required=True)
+    tipo_upr = fields.Integer(position=21, required=True)
+    energia_bilateral = fields.Integer(position=22, required=True)
+    hora = fields.Integer(position=23, required=True)
+
+
+ReganecuQhSchema()

--- a/cchloader/parsers/reganecuqh.py
+++ b/cchloader/parsers/reganecuqh.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from cchloader import logger
+from cchloader.utils import build_dict
+from cchloader.adapters.reganecuqh import ReganecuQhAdapter
+from cchloader.models.reganecuqh import ReganecuQhSchema
+from cchloader.parsers.parser import Parser, register
+import six
+if six.PY3:
+    unicode = str
+
+
+class ReganecuQh(Parser):
+
+    patterns = ['^([ABC])(\d{1})_reganecuqh_(\d{4})(\d{2})(\d{2})_']
+    encoding = "iso-8859-15"
+    delimiter = ';'
+
+    def __init__(self, strict=False):
+        self.adapter = ReganecuQhAdapter(strict=strict)
+        self.schema = ReganecuQhSchema(strict=strict)
+        self.fields = []
+        self.headers = []
+        for f in sorted(self.schema.fields, key=lambda f: self.schema.fields[f].metadata['position']):
+            field = self.schema.fields[f]
+            self.fields.append((f, field.metadata))
+            self.headers.append(f)
+
+    def parse_line(self, line):
+        slinia = tuple(unicode(line.decode(self.encoding)).split(self.delimiter))
+        slinia = list(map(lambda s: s.strip(), slinia))
+        parsed = {'reganecu': {}, 'orig': line}
+        data = build_dict(self.headers, slinia)
+        result, errors = self.adapter.load(data)
+        if errors:
+            logger.error(errors)
+        parsed['reganecu'] = result
+        return parsed, errors
+
+
+register(ReganecuQh)


### PR DESCRIPTION
## Objetivo
- Implementar el modelo, el "parser" y el "adapter" para poder importar ficheros de liquidaciones `REGANECUQH`.

## Especificaciones
- El fichero `REGANECUQH` publica los registros de anotaciones en cuenta.

![reganecuqh](https://github.com/user-attachments/assets/4fc70861-8f98-47ad-86ca-f3bc260d0d38)
