### PR TITLE
Evitar parar la importación de totas las curvas en caso de que uno de los proveedores falle.

### DIFF
--- a/scripts/get_cch.py
+++ b/scripts/get_cch.py
@@ -44,7 +44,10 @@ def get_cch(c):
     providers = c.TgComerProvider.read(provider_ids, [])
     for provider in providers:
          print "Loading {} CCH curves".format(provider['name'])
-         c.TgComerReader.reader([provider['id']])
+         try:
+             c.TgComerReader.reader([provider['id']])
+         except Exception as e:
+             print "Error loding {} CCH curves with the next error {}".format(provider['name'], e.message)
 
 if __name__ == "__main__":
    config_connection(auto_envvar_prefix='PEEK')

--- a/scripts/get_cch.py
+++ b/scripts/get_cch.py
@@ -46,8 +46,8 @@ def get_cch(c):
          print "Loading {} CCH curves".format(provider['name'])
          try:
              c.TgComerReader.reader([provider['id']])
-         except Exception as e:
-             print "Error loding {} CCH curves with the next error {}".format(provider['name'], e.message)
+         except:
+             print "Error loding {} CCH curves".format(provider['name'])
 
 if __name__ == "__main__":
    config_connection(auto_envvar_prefix='PEEK')


### PR DESCRIPTION
## Objetivos

- Evitar que al importar curvas pare el proceso si uno de los proveedores no se puede importar correctamente.

## Comportamiento antiguo

- Si uno de los proveedores fallaba, el programa no seguía haciendo los siguientes proveedores.

## Comportamiento nuevo

- En caso de fallar se muestra un mensaje con el error i se continúa con el siguiente proveedor.
