### PR TITLE
Implementar política UPSERT en el "backend" de TimeScaleDB

### DIFF
--- a/cchloader/backends/timescaledb.py
+++ b/cchloader/backends/timescaledb.py
@@ -84,6 +84,9 @@ class TimescaleDBBackend(BaseBackend):
         if 'updated_at' in columns:
             document['updated_at'] = timestamp
 
+        if 'write_date' in columns:
+            document['write_date'] = timestamp
+
         # UTC timestamp used by SOM
         if 'utc_timestamp' in columns:
             document['utc_timestamp'] = get_as_utc_timestamp(document['datetime']).strftime('%Y-%m-%d %H:%M:%S')
@@ -99,7 +102,24 @@ class TimescaleDBBackend(BaseBackend):
 
         placeholders = ', '.join(['%s'] * len(document))
         columns = ', '.join(document.keys())
-        sql = "INSERT INTO %s ( %s ) VALUES ( %s ) RETURNING *" % (collection, columns, placeholders)
+
+        on_conflict_unique_fields = cch.adapter.unique_fields
+        on_conflict_update_fields = cch.adapter.update_fields
+
+        conflict_clause = ", ".join(on_conflict_unique_fields)
+
+        set_clause = ", ".join(
+            "{} = COALESCE(EXCLUDED.{}, giscedata_epfpf.{})".format(field, field, field)
+            for field in on_conflict_update_fields
+        )
+
+
+        sql = """
+              INSERT INTO %s ( %s ) VALUES ( %s )
+              ON CONFLICT (%s)
+              DO UPDATE SET %s
+              RETURNING *
+              """ % (collection, columns, placeholders, conflict_clause, set_clause)
         self.cr.execute(sql, document.values())
         oid = self.cr.fetchone()[0]
         self.db.commit()

--- a/cchloader/backends/timescaledb.py
+++ b/cchloader/backends/timescaledb.py
@@ -84,6 +84,10 @@ class TimescaleDBBackend(BaseBackend):
         if 'updated_at' in columns:
             document['updated_at'] = timestamp
 
+        # Create and Write date
+        if 'create_date' in columns:
+            document['create_date'] = timestamp
+
         if 'write_date' in columns:
             document['write_date'] = timestamp
 

--- a/cchloader/backends/timescaledb.py
+++ b/cchloader/backends/timescaledb.py
@@ -4,12 +4,15 @@ from __future__ import absolute_import
 from cchloader.backends import BaseBackend, register, urlparse
 import datetime
 import psycopg2
+from psycopg2.extras import execute_values
 import pytz
+
 
 def get_as_utc_timestamp(t):
     timezone_utc = pytz.timezone("UTC")
     timezone_local = pytz.timezone("Europe/Madrid")
     return timezone_utc.normalize(timezone_local.localize(t, is_dst=False))
+
 
 def get_utc_timestamp_from_datetime_and_season(local_timestamp, season):
     """
@@ -25,6 +28,7 @@ def get_utc_timestamp_from_datetime_and_season(local_timestamp, season):
         timezone_local.localize(local_timestamp, is_dst=dst))
     ).astimezone(timezone_utc)
     return utc_timestamp
+
 
 class TimescaleDBBackend(BaseBackend):
     """TimescaleDB Backend
@@ -45,34 +49,73 @@ class TimescaleDBBackend(BaseBackend):
                 " password=" + self.config['password']
         self.db = psycopg2.connect(ts_con)
         self.cr = self.db.cursor()
-
+        self._columns_cache = {}
 
     def insert(self, document):
-        for collection in document.keys():
-            if collection in self.collections:
+        self.insert_batch([document])
+
+    def insert_batch(self, documents, page_size=1000):
+        grouped_rows = {}
+
+        for document in documents:
+            for collection in document.keys():
+                if collection not in self.collections:
+                    continue
+
                 cch = document.get(collection)
-                if cch:
-                    cch.backend = self
-                    cch.collection = collection
-                    self.insert_cch(cch)
+                if not cch:
+                    continue
+
+                cch.backend = self
+                cch.collection = collection
+                prepared = self._prepare_cch_document(cch)
+
+                column_names = tuple(sorted(prepared.keys()))
+                unique_fields = tuple(cch.adapter.unique_fields)
+                update_fields = tuple(
+                    [field for field in cch.adapter.update_fields if field in prepared]
+                )
+
+                group_key = (collection, column_names, unique_fields, update_fields)
+                grouped_rows.setdefault(group_key, []).append(
+                    tuple(prepared[column] for column in column_names)
+                )
+
+        grouped_iter = grouped_rows.iteritems() if hasattr(grouped_rows, 'iteritems') else grouped_rows.items()
+
+        for group_key, rows in grouped_iter:
+            collection, column_names, unique_fields, update_fields = group_key
+            sql = self._build_upsert_sql(
+                collection,
+                column_names,
+                unique_fields,
+                update_fields
+            )
+            execute_values(self.cr, sql, rows, page_size=page_size)
+
+        if grouped_rows:
+            self.db.commit()
 
     def get_columns(self, collection):
+        if collection in self._columns_cache:
+            return self._columns_cache[collection]
+
         self.cr.execute(
             "SELECT column_name FROM information_schema.columns "
             "WHERE table_name = %s", (collection, )
         )
-        return [x[0] for x in self.cr.fetchall()]
+        columns = [x[0] for x in self.cr.fetchall()]
+        self._columns_cache[collection] = columns
+        return columns
 
-    def insert_cch(self, cch):
+    def _prepare_cch_document(self, cch):
         collection = cch.collection
-        document = cch.backend_data
-
+        document = dict(cch.backend_data)
         columns = self.get_columns(collection)
-
         timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
         # UTC timestamp used by GISCE
-        if 'timestamp' in columns:
+        if 'timestamp' in columns and 'local_timestamp' in document and 'season' in document:
             utc_timestamp = get_utc_timestamp_from_datetime_and_season(
                 document['local_timestamp'], document['season']
             ).strftime('%Y-%m-%d %H:%M:%S')
@@ -92,7 +135,7 @@ class TimescaleDBBackend(BaseBackend):
             document['write_date'] = timestamp
 
         # UTC timestamp used by SOM
-        if 'utc_timestamp' in columns:
+        if 'utc_timestamp' in columns and 'datetime' in document:
             document['utc_timestamp'] = get_as_utc_timestamp(document['datetime']).strftime('%Y-%m-%d %H:%M:%S')
 
         if 'validated' in document and type(document['validated']) == bool:
@@ -104,30 +147,58 @@ class TimescaleDBBackend(BaseBackend):
         if 'name' in document and type(document['name']) == type(u''):
             document['name'] = document['name'].encode('utf-8')
 
-        placeholders = ', '.join(['%s'] * len(document))
-        columns = ', '.join(document.keys())
+        return document
 
-        on_conflict_unique_fields = cch.adapter.unique_fields
-        on_conflict_update_fields = cch.adapter.update_fields
+    @staticmethod
+    def _build_upsert_sql(collection, column_names, unique_fields, update_fields):
+        columns_sql = ', '.join(column_names)
+        conflict_clause = ', '.join(unique_fields)
 
-        conflict_clause = ", ".join(on_conflict_unique_fields)
+        if not update_fields:
+            return (
+                "INSERT INTO {table} ({columns}) VALUES %s "
+                "ON CONFLICT ({conflict}) DO NOTHING"
+            ).format(
+                table=collection,
+                columns=columns_sql,
+                conflict=conflict_clause
+            )
 
-        set_clause = ", ".join(
-            "{} = COALESCE(EXCLUDED.{}, giscedata_epfpf.{})".format(field, field, field)
-            for field in on_conflict_update_fields
+        set_clause = ', '.join(
+            "{field} = COALESCE(EXCLUDED.{field}, {table}.{field})".format(
+                field=field, table=collection
+            )
+            for field in update_fields
         )
 
+        return (
+            "INSERT INTO {table} ({columns}) VALUES %s "
+            "ON CONFLICT ({conflict}) DO UPDATE SET {set_clause}"
+        ).format(
+            table=collection,
+            columns=columns_sql,
+            conflict=conflict_clause,
+            set_clause=set_clause
+        )
 
-        sql = """
-              INSERT INTO %s ( %s ) VALUES ( %s )
-              ON CONFLICT (%s)
-              DO UPDATE SET %s
-              RETURNING *
-              """ % (collection, columns, placeholders, conflict_clause, set_clause)
-        self.cr.execute(sql, document.values())
-        oid = self.cr.fetchone()[0]
+    def insert_cch(self, cch):
+        prepared = self._prepare_cch_document(cch)
+        column_names = tuple(sorted(prepared.keys()))
+        unique_fields = tuple(cch.adapter.unique_fields)
+        update_fields = tuple(
+            [field for field in cch.adapter.update_fields if field in prepared]
+        )
+
+        sql = self._build_upsert_sql(
+            cch.collection,
+            column_names,
+            unique_fields,
+            update_fields
+        )
+        row = tuple(prepared[column] for column in column_names)
+        execute_values(self.cr, sql, [row], page_size=1)
         self.db.commit()
-        return oid
+        return None
 
     def get(self, collection, filters, fields=None):
         raise Exception("Not implemented cchloader.backend.timescale.get()")

--- a/cchloader/models/epfpf.py
+++ b/cchloader/models/epfpf.py
@@ -18,5 +18,10 @@ class EPFPFSchema(Schema):
     cierre = fields.String(position=8, validate=OneOf(['P','D','']))
     tipo_medida = fields.Integer(position=9, validate=OneOf(tipomedida_valid))
 
+    # Constrain fields
+    unique_fields = ['timestamp', 'name', 'type']
+    # Upsert fields
+    update_fields = ['ai', 'ae', 'r1', 'r2', 'r3', 'r4', 'firmeza', 'cierre', 'tipo_medida', 'write_date']
+
 
 EPFPFSchema()

--- a/cchloader/parsers/epfpf.py
+++ b/cchloader/parsers/epfpf.py
@@ -79,7 +79,9 @@ class EPFPF(Parser):
 
     def get_magn(self, data):
         magn = data.get('magnitud').lower()
-        if magn == 'as':
+        if magn == 'ae':
+            magn = 'ai'
+        elif magn == 'as':
             magn = 'ae'
         data[magn] = data.get('valor')
         for field in ['magnitud', 'valor']:

--- a/cchloader/parsers/reganecu.py
+++ b/cchloader/parsers/reganecu.py
@@ -36,6 +36,8 @@ class Reganecu(Parser):
         result, errors = self.adapter.load(data)
         if errors:
             logger.error(errors)
+            pass
+
         parsed['reganecu'] = result
         return parsed, errors
 

--- a/cchloader/parsers/reganecuqh.py
+++ b/cchloader/parsers/reganecuqh.py
@@ -36,6 +36,7 @@ class ReganecuQh(Parser):
         result, errors = self.adapter.load(data)
         if errors:
             logger.error(errors)
+            pass
         parsed['reganecu'] = result
         return parsed, errors
 


### PR DESCRIPTION
## Objetivos

- Añadir dos atributos a los modelos de TimeScaleDB para poder aplicar política "ON CONFLICT" si al inserir registros se viola la restricción única.

## Comportamiento antiguo

- Falla la inserción.

## Comportamiento nuevo

- Se realiza una actualización de los registros existentes.

## Relacionado

- Improves https://github.com/gisce/cchloader/pull/56
- Task 66781
